### PR TITLE
(dependabot/fix): correct dependency name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
         patterns:
           - "@citizenfx*"
           - "@nativewrappers*"
-          - "@overextended/ox_lib"
+          - "@communityox/ox_lib"
       main-dependencies:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
- changed dependency in dependabot to use communityox/ox_lib instead of overextended/ox_lib